### PR TITLE
Partial Resolution to Issue #24

### DIFF
--- a/models/BaseORMService.cfc
+++ b/models/BaseORMService.cfc
@@ -725,8 +725,9 @@ component accessors="true"{
 		if( !isNull( arguments.id ) ){
 			// type safe conversions
 			arguments.id = convertIDValueToJavaType( entityName=arguments.entityName, id=arguments.id );
-			var identifierProperty = getEntityMetadata( entityNew( arguments.entityName ) ).getIdentifierPropertyName();
-			hql &= " WHERE #identifierProperty# in (:idlist)";
+			// `id` is a hibernate keyword, not the column name, in this case: 
+			//  https://docs.jboss.org/hibernate/orm/3.3/reference/en-US/html/queryhql.html
+			hql &= " WHERE id in (:idlist)";
 		}
 
 		// Sorting
@@ -897,11 +898,9 @@ component accessors="true"{
 
 		// type safe conversions
 		arguments.id = convertIDValueToJavaType(entityName=arguments.entityName, id=arguments.id);
-
-		// delete using lowercase id convention from hibernate for identifier
-		var datasource = orm.getEntityDatasource(arguments.entityName);
-		var identifierProperty = getEntityMetadata( entityNew( arguments.entityName ) ).getIdentifierPropertyName();
-		var query = orm.getSession(datasource).createQuery("delete FROM #arguments.entityName# where #identifierProperty# in (:idlist)");
+		// delete using lowercase id convention from hibernate for identifier		
+		//  https://docs.jboss.org/hibernate/orm/3.3/reference/en-US/html/queryhql.html
+		var query = orm.getSession(datasource).createQuery("delete FROM #arguments.entityName# where id in (:idlist)");
 		query.setParameterList("idlist",arguments.id);
 		count = query.executeUpdate();
 

--- a/models/BaseORMService.cfc
+++ b/models/BaseORMService.cfc
@@ -1,4 +1,4 @@
-﻿/**
+/**
 * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
 * www.ortussolutions.com
 * ---
@@ -643,23 +643,14 @@ component accessors="true"{
 	}
 
 	/**
-     * Checks if the given entityName and id exists in the database, this method does not load the entity into session
+     * Checks if the given entityName and id exists in the database
 	 *
 	 * @entityName The name of the entity
 	 * @id The id to lookup
 	 */
 	boolean function exists( required entityName, required any id ){
-		// Do it DLM style
-		var count = ORMExecuteQuery(
-			"select count( id ) from #arguments.entityName# where id = ?",
-			[ arguments.id ],
-			true,
-			{
-				datasource = variables.ORM.getEntityDatasource( arguments.entityName )
-			}
-		);
-
-		return ( count gt 0 );
+		var identifierProperty = getEntityMetadata( entityNew( arguments.entityName ) ).getIdentifierPropertyName();
+		return javacast( "boolean", new CriteriaBuilder( arguments.entityName, false, "", this ).isEq( identifierProperty, arguments.id ).count() );
 	}
 
 	/**
@@ -734,7 +725,8 @@ component accessors="true"{
 		if( !isNull( arguments.id ) ){
 			// type safe conversions
 			arguments.id = convertIDValueToJavaType( entityName=arguments.entityName, id=arguments.id );
-			hql &= " WHERE id in (:idlist)";
+			var identifierProperty = getEntityMetadata( entityNew( arguments.entityName ) ).getIdentifierPropertyName();
+			hql &= " WHERE #identifierProperty# in (:idlist)";
 		}
 
 		// Sorting
@@ -908,7 +900,8 @@ component accessors="true"{
 
 		// delete using lowercase id convention from hibernate for identifier
 		var datasource = orm.getEntityDatasource(arguments.entityName);
-		var query = orm.getSession(datasource).createQuery("delete FROM #arguments.entityName# where id in (:idlist)");
+		var identifierProperty = getEntityMetadata( entityNew( arguments.entityName ) ).getIdentifierPropertyName();
+		var query = orm.getSession(datasource).createQuery("delete FROM #arguments.entityName# where #identifierProperty# in (:idlist)");
 		query.setParameterList("idlist",arguments.id);
 		count = query.executeUpdate();
 

--- a/test-harness/tests/specs/BaseORMServiceTest.cfc
+++ b/test-harness/tests/specs/BaseORMServiceTest.cfc
@@ -190,7 +190,7 @@
 
 	function testgetKeyValue(){
 		var test = entityLoad( "category", "A13C0DB0-0CBC-4D85-A5261F2E3FCBEF91", true );
-		var targetID = ormService.getKeyValue( test )
+		var targetID = ormService.getKeyValue( test );
 		expect( targetID ).toBe( "A13C0DB0-0CBC-4D85-A5261F2E3FCBEF91" );
 
 		var targetID = ormService.getKeyValue( entityNew( "Category" ) );


### PR DESCRIPTION
Converts the usage of `id` as a hard-coded identifier in `BaseORMService` to use dynamic key name.

Downside:  Dynamically pulling the key name requires a load of the object graph via entityNew()