### PR TITLE
Fix for Adobe 2016 Errors

### DIFF
--- a/models/BaseORMService.cfc
+++ b/models/BaseORMService.cfc
@@ -1000,7 +1000,8 @@ component accessors="true"{
 			);
 		}
 
-		var dirtyArray 		= hibernateMD.findModified( dbState, currentState, arguments.entity, thisSession ) ?: [];
+		var modified = hibernateMD.findModified( dbState, currentState, arguments.entity, thisSession );
+		var dirtyArray 	= !isNull( modified ) ? modified : [];
 
 		return arrayMap( dirtyArray, function( index ){
 			return hibernateMD.getSubclassPropertyName( index );
@@ -1032,7 +1033,9 @@ component accessors="true"{
 				arguments.entity
 			);
 		}
-		var dirtyArray 		= hibernateMD.findModified( dbState, currentState, arguments.entity, thisSession ) ?: [];
+		
+		var modified = hibernateMD.findModified( dbState, currentState, arguments.entity, thisSession );
+		var dirtyArray 	= !isNull( modified ) ? modified : [];
 
 		return ( arrayLen( dirtyArray ) > 0 );
 	}

--- a/models/BaseORMService.cfc
+++ b/models/BaseORMService.cfc
@@ -1001,7 +1001,7 @@ component accessors="true"{
 		}
 
 		var modified = hibernateMD.findModified( dbState, currentState, arguments.entity, thisSession );
-		var dirtyArray 	= !isNull( modified ) ? modified : [];
+		var dirtyArray 	= !isNull( local.modified ) ? modified : [];
 
 		return arrayMap( dirtyArray, function( index ){
 			return hibernateMD.getSubclassPropertyName( index );
@@ -1035,7 +1035,7 @@ component accessors="true"{
 		}
 		
 		var modified = hibernateMD.findModified( dbState, currentState, arguments.entity, thisSession );
-		var dirtyArray 	= !isNull( modified ) ? modified : [];
+		var dirtyArray 	= !isNull( local.modified ) ? modified : [];
 
 		return ( arrayLen( dirtyArray ) > 0 );
 	}


### PR DESCRIPTION
The Elvis operator has flaws in 2016 and will throw an error when the session is unmodified as the Elvis operator is returning `null`

The current implementation of these methods is not compatible with 2016