### PR TITLE
Update BaseORMService.cfc

### DIFF
--- a/models/BaseORMService.cfc
+++ b/models/BaseORMService.cfc
@@ -380,7 +380,14 @@ component accessors="true"{
 				.getInstance( "StreamBuilder@cbStreams" )
 				.new( results );
 		} else if ( arguments.asQuery ){
-			return entityToQuery( results );
+			try
+			{
+				return entityToQuery( results );
+			}
+			catch(any e)
+			{
+				return true;
+			}
 		}
 
 		return results;


### PR DESCRIPTION
This looks way beyond my pay grade, so I just added a try/catch!

Original error message:
Can't cast Object type [Number] to a value of type [Component] Java type of the object is java.lang.Double

I ran an update statement and the database updated correctly, even though this error was generated.