### PR TITLE
Don't return new entities for getOrFail

### DIFF
--- a/models/BaseORMService.cfc
+++ b/models/BaseORMService.cfc
@@ -400,7 +400,11 @@ component accessors="true"{
 		required string entityName,
 		required any id
 	){
-		var result = this.get( argumentCollection=arguments );
+		var result = this.get(
+		    entityName = arguments.entityName,
+		    id = arguments.id,
+			returnNew = false
+		);
 		if( isNull( result ) ){
 			throw(
 				message = "No entity found for ID #arguments.id.toString()#",


### PR DESCRIPTION
Returning new entities on `getOrFail` defeats the purpose of the helper as it will never be null.