### PR TITLE
Added entityname in extendedinfo

### DIFF
--- a/models/BaseORMService.cfc
+++ b/models/BaseORMService.cfc
@@ -424,7 +424,7 @@ component accessors="true" {
 			returnNew  = false
 		);
 		if ( isNull( result ) ) {
-			throw( message = "No entity found for ID #arguments.id.toString()#", type = "EntityNotFound" );
+			throw( message = "No entity found for ID #arguments.id.toString()#", type = "EntityNotFound", extendedinfo = arguments.entityName );
 		}
 		return result;
 	}


### PR DESCRIPTION
So we can distinguish between  multiple getOrFail statements in code, to see which entitytype is failing.
I use this to supply different enduser error messages, based on the extended info entityname