### PR TITLE
CBORM-4 Change defaultAsQuery to a default of false instead of true

### DIFF
--- a/models/ActiveEntity.cfc
+++ b/models/ActiveEntity.cfc
@@ -32,7 +32,7 @@ component extends="cborm.models.VirtualEntityService" accessors="true" {
 	 * @useQueryCaching Enable query caching for this entity or not, defaults to false
 	 * @eventHandling Enable event handling for new() and save() operations, defaults to true
 	 * @useTransactions Enable transactions for all major operations, defaults to true
-	 * @defaultAsQuery Return query or array of objects on list(), executeQuery() defaults to true
+	 * @defaultAsQuery Return query or array of objects on list(), executeQuery() defaults to false
 	 */
 	function init(
 		string queryCacheRegion,

--- a/models/BaseORMService.cfc
+++ b/models/BaseORMService.cfc
@@ -69,7 +69,7 @@ component accessors="true" {
 	property
 		name      ="defaultAsQuery"
 		type      ="boolean"
-		default   ="true"
+		default   ="false"
 		persistent="false";
 
 	/**
@@ -109,7 +109,7 @@ component accessors="true" {
 		boolean useQueryCaching = false,
 		boolean eventHandling   = true,
 		boolean useTransactions = true,
-		boolean defaultAsQuery  = true,
+		boolean defaultAsQuery  = false,
 		string datasource
 	){
 		// setup local properties

--- a/models/BaseORMService.cfc
+++ b/models/BaseORMService.cfc
@@ -64,7 +64,7 @@ component accessors="true" {
 		persistent="false";
 
 	/**
-	 * The bit that determines the default return value for list(), createCriteriaQuery() and executeQuery() as query or arrays, default is query for listing
+	 * The bit that determines the default return value for list(), createCriteria() and executeQuery() as query or arrays, default is query for listing
 	 */
 	property
 		name      ="defaultAsQuery"

--- a/models/VirtualEntityService.cfc
+++ b/models/VirtualEntityService.cfc
@@ -51,7 +51,7 @@ component extends="cborm.models.BaseORMService" accessors="true" {
 	 * @useQueryCaching Activate query caching, defaults to false
 	 * @eventHandling Activate event handling, defaults to true
 	 * @useTransactions Activate transaction blocks on calls, defaults to true
-	 * @defaultAsQuery Return query or array of objects on list(), executeQuery() defaults to true
+	 * @defaultAsQuery Return query or array of objects on list(), executeQuery() defaults to false
 	 * @datasource THe datsource name to be used for the rooted entity, if not we use the default datasource
 	 */
 	VirtualEntityService function init(

--- a/test-harness/tests/specs/ActiveEntityTest.cfc
+++ b/test-harness/tests/specs/ActiveEntityTest.cfc
@@ -282,7 +282,8 @@
 	function testList(){
 		test = activeUser.list( sortorder = "lastName asc" );
 
-		assertTrue( test.recordcount );
+		assertTrue( isArray( test ) );
+		assertTrue( arrayLen(test ) );
 	}
 
 	function testFindWhere(){

--- a/test-harness/tests/specs/BaseORMServiceTest.cfc
+++ b/test-harness/tests/specs/BaseORMServiceTest.cfc
@@ -702,29 +702,30 @@
 			sortorder  = "category asc",
 			criteria   = criteria
 		);
-		assertTrue( test.recordcount );
+		assertTrue( arrayLen( test ) );
 
 		// as array
-		ormservice.setDefaultAsQuery( false );
+		ormservice.setDefaultAsQuery( true );
 		test = ormservice.list(
 			entityName = "Category",
 			sortorder  = "category asc",
 			criteria   = criteria
 		);
-		assertTrue( arrayLen( test ) );
+		assertTrue( test.recordcount );
 	}
 
 	function testExecuteQuery(){
 		test = ormservice.executeQuery( query = "from Category" );
 		debug( test );
-		assertTrue( test.recordcount );
+		assertTrue( isArray( test ) );
+		assertTrue( arrayLen( test ) );
 
 		params = [ "general" ];
 		test   = ormservice.executeQuery(
 			query  = "from Category where category = ?",
 			params = params
 		);
-		assertTrue( test.recordcount );
+		assertTrue( arrayLen( test ) );
 	}
 
 	function testExecuteQueryWithUpdate(){

--- a/test-harness/tests/specs/VirtualEntityServiceTest.cfc
+++ b/test-harness/tests/specs/VirtualEntityServiceTest.cfc
@@ -186,7 +186,8 @@
 	function testList(){
 		test = ormservice.list( sortorder = "lastName asc" );
 
-		assertTrue( test.recordcount );
+		assertTrue( isArray( test) );
+		assertTrue( arrayLen( test ) );
 	}
 
 	function testFindWhere(){


### PR DESCRIPTION
This PR introduces a breaking change by changing defaultAsQuery from **true** to **false**. This means list operations will return an array by default and you must explicitly request a query to be returned in the API.