### PR TITLE
Patch/active entity evict

### DIFF
--- a/models/ActiveEntity.cfc
+++ b/models/ActiveEntity.cfc
@@ -141,7 +141,7 @@ component extends="cborm.models.VirtualEntityService" accessors="true" {
 	 * @entity The argument can be one persistence entity or an array of entities to evict
 	 */
 	any function evict( any entity = this ){
-		return super.evictEntity( arguments.entities );
+		return super.evict( arguments.entity );
 	}
 
 	/**

--- a/models/BaseORMService.cfc
+++ b/models/BaseORMService.cfc
@@ -1747,7 +1747,12 @@ component accessors="true" {
 		}
 
 		arguments.entities.each( function( item ){
-			variables.ORM.getSession( variables.orm.getEntityDatasource( item ) ).evict( item );
+			/**
+			 * Beware of eviction issues in Adobe 2016 and Adobe 2018
+			 * https://hibernate.atlassian.net/browse/HHH-9013?oldIssueView=true
+			 * https://tracker.adobe.com/#/view/CF-4212321
+			 */
+			ormEvictEntity( getEntityGivenName( item ), getKeyValue( item ) );
 		} );
 
 		return this;

--- a/models/BaseORMService.cfc
+++ b/models/BaseORMService.cfc
@@ -1747,12 +1747,7 @@ component accessors="true" {
 		}
 
 		arguments.entities.each( function( item ){
-			/**
-			 * Beware of eviction issues in Adobe 2016 and Adobe 2018
-			 * https://hibernate.atlassian.net/browse/HHH-9013?oldIssueView=true
-			 * https://tracker.adobe.com/#/view/CF-4212321
-			 */
-			ormEvictEntity( getEntityGivenName( item ), getKeyValue( item ) );
+			variables.ORM.getSession( variables.orm.getEntityDatasource( item ) ).evict( item );
 		} );
 
 		return this;

--- a/test-harness/.cfconfig.json
+++ b/test-harness/.cfconfig.json
@@ -4,7 +4,7 @@
             "class":"${DB_CLASS}",
 			"dbdriver": "MySQL",
 			"dsn":"jdbc:mysql://{host}:{port}/{database}",
-            "custom":"useUnicode=true&characterEncoding=UTF8&serverTimezone=America%2FChicago&useLegacyDatetimeCode=true&autoReconnect=true&useSSL=false",
+            "custom":"useUnicode=true&characterEncoding=UTF8&serverTimezone=America%2FChicago&useLegacyDatetimeCode=true&autoReconnect=true&useSSL=false&allowPublicKeyRetrieval=true",
             "host":"${DB_HOST:127.0.0.1}",
             "username": "${DB_USER:root}",
             "password": "${DB_PASSWORD}",

--- a/test-harness/tests/specs/ActiveEntityTest.cfc
+++ b/test-harness/tests/specs/ActiveEntityTest.cfc
@@ -19,7 +19,7 @@
 
 	function testEvictionByEntityObject(){
 		ormClearSession();
-		var test = getMockBox().prepareMock( entityNew( "ActiveUser" ) );
+		var test = entityLoad( "ActiveUser", testUserID, true );
 		test.evict();
 		expect( test.sessionContains( test ) ).toBeFalse();
 	}

--- a/test-harness/tests/specs/ActiveEntityTest.cfc
+++ b/test-harness/tests/specs/ActiveEntityTest.cfc
@@ -17,6 +17,13 @@
 		testCatID  = "3A2C516C-41CE-41D3-A9224EA690ED1128";
 	}
 
+	function testEvictionByEntityObject(){
+		ormClearSession();
+		var test = getMockBox().prepareMock( entityNew( "ActiveUser" ) );
+		test.evict();
+		expect( test.sessionContains( test ) ).toBeFalse();
+	}
+
 	function testCountByDynamically(){
 		// Test simple Equals
 		t = activeUser.countByLastName( "majano" );


### PR DESCRIPTION
This PR resolves a `key [ENTITIES] doesn't exist in argument scope. existing keys are [entity]` error when calling `entity.evict()` on an `ActiveEntity` object.

![Screenshot from 2021-07-29 14-12-56](https://user-images.githubusercontent.com/8106227/127544083-8fb2bf0b-eff8-4630-84fc-6c87396cf083.png)
