### PR TITLE
feat: Add `isInTransaction()` util helper method

### DIFF
--- a/models/util/ORMUtilSupport.cfc
+++ b/models/util/ORMUtilSupport.cfc
@@ -152,4 +152,17 @@ component {
 		return getSessionFactory( arguments.datasource ).getClassMetaData( arguments.entityName );
 	}
 
+    /**
+     * Cross-engine transaction detection.
+     * Useful for preventing nested transactions.
+     * 
+     * @see https://dev.lucee.org/t/determine-if-code-is-inside-cftransaction/7358
+     */
+    public boolean function isInTransaction(){
+        if ( listFindNoCase( "Lucee", server.coldfusion.productname ) ) {
+            return ORMGetSession().isTransactionInProgress();
+        } else {
+            return ORMGetSession().getActualSession().isTransactionInProgress();
+        }
+    }
 }


### PR DESCRIPTION
This adds the ability to check whether the current executing code is inside a Hibernate transaction. Useful for preventing nested transactions:

```js
myEntity.save(
  flush = true,
  transactional = !getORMUtil().isInTransaction()
);
```