### PR TITLE
🐛 FIX: Workaround Hibernate 5.3+ gotchas in exists()

### DIFF
--- a/models/BaseORMService.cfc
+++ b/models/BaseORMService.cfc
@@ -1577,8 +1577,8 @@ component accessors="true" {
 	boolean function exists( required entityName, required any id ){
 		// Do it DLM style
 		var count = ormExecuteQuery(
-			"select count( id ) from #arguments.entityName# where id = ?",
-			[ arguments.id ],
+			"select count( id ) from #arguments.entityName# where id = :id",
+			{ id : arguments.id },
 			true,
 			{ datasource : variables.ORM.getEntityDatasource( arguments.entityName ) }
 		);


### PR DESCRIPTION
Positional parameter syntax changed in Hibernate 5.3, and the old syntax is no longer supported. For best compatibility across Hibernate versions, simply use named parameters.

Resolves this error message:

```
org.hibernate.QueryException: Legacy-style query parameters (`?`) are no longer supported;
use JPA-style ordinal parameters (e.g., `?1`) instead :
select count( id ) from Category where id = ? [select count( id ) from Category where id = ?]
```

![Screenshot of failing exists test in CBORM test suite](https://user-images.githubusercontent.com/8106227/140065857-c852f2d2-66da-4b30-b515-02db281dbfe2.png)