### PR TITLE
🐛 FIX: Restart test app if coldbox bootstrap failed

### DIFF
--- a/test-harness/Application.cfc
+++ b/test-harness/Application.cfc
@@ -87,6 +87,9 @@ component {
 
 	// request start
 	public boolean function onRequestStart( String targetPage ){
+		if ( !structKeyExists( application, "cbBootstrap" ) ){
+			onApplicationStart();
+		}
 		if ( url.keyExists( "fwreinit" ) ) {
 			if ( server.keyExists( "lucee" ) ) {
 				pagePoolClear();


### PR DESCRIPTION
This works around an issue where an error on application start (such as a datasource connection issue) prevents the `onApplicationStart()` method from firing. When this happens, the test app is left in an unloaded state and ColdBox is not ready for testing.

To fix, we simply re-run `onApplicationStart()` if the bootstrap class is not found.