### PR TITLE
📦 NEW: Add hibernate version to debug output

### DIFF
--- a/test-harness/tests/resources/BaseTest.cfc
+++ b/test-harness/tests/resources/BaseTest.cfc
@@ -13,6 +13,9 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/root" {
 	function beforeAll(){
 		super.beforeAll();
 		getWireBox().autowire( this );
+
+		var ormUtil = createMock( "cborm.models.util.ORMUtilSupport" );
+		debug( "Hibernate version is: #ormUtil.getHibernateVersion()#" );
 	}
 
 	// executes after all suites+specs in the run() method


### PR DESCRIPTION
Since we're running CBORM tests on three different versions of Hibernate, it's pretty useful to see the Hibernate version in the test suite.

I threw this in the `debug` panel for now. In the future, could we add this to the Testbox header - right next to the CF engine version?

![hibernate-version-cborm-debug-output](https://user-images.githubusercontent.com/8106227/140067324-a0ea2799-2a7a-4d7f-b9a6-909c4b783a61.png)
