### PR TITLE
Allow SQL projections to be functions containing commas

### DIFF
--- a/models/criterion/BaseBuilder.cfc
+++ b/models/criterion/BaseBuilder.cfc
@@ -751,12 +751,19 @@ component accessors="true" {
 		var partialSQL = "";
 		projection.sql = "";
 		// if multiple subqueries have been specified, smartly separate them out into a sql string that will work
-		for ( var x = 1; x <= listLen( arguments.rawProjection.sql ); x++ ) {
-			partialSQL     = listGetAt( arguments.rawProjection.sql, x );
-			partialSQL     = reFindNoCase( "^select", partialSQL ) ? "(#partialSQL#)" : partialSQL;
-			partialSQL     = partialSQL & " as #listGetAt( arguments.rawProjection.alias, x )#";
+		if ( listLen( arguments.rawProjection.sql ) > 1 && listLen( arguments.rawProjection.alias ) > 1 ) {
+			for ( var x = 1; x <= listLen( arguments.rawProjection.sql ); x++ ) {
+				partialSQL     = listGetAt( arguments.rawProjection.sql, x );
+				partialSQL     = reFindNoCase( "^select", partialSQL ) ? "(#partialSQL#)" : partialSQL;
+				partialSQL     = partialSQL & " as #listGetAt( arguments.rawProjection.alias, x )#";
+				projection.sql = listAppend( projection.sql, partialSQL );
+			}
+		} else {
+			partialSQL     = arguments.rawProjection.sql;
+			partialSQL     = partialSQL & " as #arguments.rawProjection.alias#";
 			projection.sql = listAppend( projection.sql, partialSQL );
 		}
+		
 		// get all aliases
 		projection.alias = listToArray( arguments.rawProjection.alias );
 		// if there is a grouping spcified, add it to structure

--- a/test-harness/tests/specs/criterion/BaseBuilderTest.cfc
+++ b/test-harness/tests/specs/criterion/BaseBuilderTest.cfc
@@ -176,8 +176,8 @@ component extends="tests.resources.BaseTest" {
 						property : "id"
 					},
 					{
-						sql      : "DATEDIFF('2021-12-31 23:59:59','2021-12-30')",
-						group    : "DATEDIFF('2021-12-31 23:59:59','2021-12-30')",
+						sql      : "dateDiff('2021-12-31 23:59:59','2021-12-30')",
+						group    : "dateDiff('2021-12-31 23:59:59','2021-12-30')",
 						alias    : "someDateDiff",
 						property : "id"
 					}

--- a/test-harness/tests/specs/criterion/BaseBuilderTest.cfc
+++ b/test-harness/tests/specs/criterion/BaseBuilderTest.cfc
@@ -173,8 +173,8 @@ component extends="tests.resources.BaseTest" {
 							property : "id"
 						},
 						{
-							sql      : "DATEDIFF('2021-12-31 23:59:59','2021-12-30')",
-							group    : "DATEDIFF('2021-12-31 23:59:59','2021-12-30')",
+							sql      : "dateDiff('2021-12-31 23:59:59','2021-12-30')",
+							group    : "dateDiff('2021-12-31 23:59:59','2021-12-30')",
 							alias    : "someDateDiff",
 							property : "id"
 						}

--- a/test-harness/tests/specs/criterion/BaseBuilderTest.cfc
+++ b/test-harness/tests/specs/criterion/BaseBuilderTest.cfc
@@ -152,6 +152,36 @@ component extends="tests.resources.BaseTest" {
 			)
 			.list();
 		assertTrue( isArray( r ) );
+
+		var categoryCriteria = new cborm.models.criterion.CriteriaBuilder( entityName = "Category", ORMService = ormService );
+
+		r = categoryCriteria
+				.withProjections(
+					groupProperty = "catid",
+					sqlProjection = [
+						{
+							sql      : "count( category_id )",
+							alias    : "count",
+							property : "catid"
+						}
+					],
+					sqlGroupProjection = [
+						{
+							sql      : "year( modifydate )",
+							group    : "year( modifydate )",
+							alias    : "modifiedDate",
+							property : "id"
+						},
+						{
+							sql      : "DATEDIFF('2021-12-31 23:59:59','2021-12-30')",
+							group    : "DATEDIFF('2021-12-31 23:59:59','2021-12-30')",
+							alias    : "someDateDiff",
+							property : "id"
+						}
+					]
+				).list()
+
+		assertTrue( isArray( r ) );
 	}
 
 	function testOrder(){


### PR DESCRIPTION
We ran into as issue where using DATEPART( iso_week, c.createdTime ) would blow up because it was using the same alias.