### PR TITLE
🤖 TEST: Add Hibernate 5.4 to the test suite engine matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cfengine: [ "lucee@5", "adobe@2016", "adobe@2018", "adobe@2021" ]
+        cfengine: [ "lucee-hibernate@5.4","lucee@5", "adobe@2016", "adobe@2018", "adobe@2021" ]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/server-lucee-hibernate@5.4.json
+++ b/server-lucee-hibernate@5.4.json
@@ -18,7 +18,7 @@
     },
     "jvm":{
         "heapSize":"1024",
-        "args":"-Dlucee.extensions='https://ext.lucee.org/hibernate-orm-5.4.29.6-BETA.lex'"
+        "args":"-Dlucee.extensions='https://ext.lucee.org/hibernate-orm-5.4.29.13-BETA.lex'"
     },
     "openBrowser":"false",
 	"cfconfig": {


### PR DESCRIPTION
Add Hibernate 5.4 on Lucee 5 to the test suite so we can run CBORM against the latest available Hibernate on Lucee.