### PR TITLE
CBORM-34

### DIFF
--- a/models/criterion/DetachedCriteriaBuilder.cfc
+++ b/models/criterion/DetachedCriteriaBuilder.cfc
@@ -31,17 +31,11 @@ component accessors="true" extends="cborm.models.criterion.BaseBuilder" {
 			.buildJavaProxy( "org.hibernate.criterion.DetachedCriteria" )
 			.forEntityName( arguments.entityName, arguments.alias );
 
-		// We don't use the normal restrictions object, we use the subclass: SubQueries specific to detached criteria queries
-		var subQueriesRestrictions = arguments.ormService
-			.getWireBox()
-			.getInstance( "SubQueries@cborm" )
-			.setDetachedCriteria( detachedCriteria );
-
 		// Super size me
 		super.init(
 			entityName  : arguments.entityName,
 			criteria    : detachedCriteria,
-			restrictions: subQueriesRestrictions,
+			restrictions: new Subqueries( arguments.ormService.getWireBox().getInstance( "JavaProxyBuilder@cborm" ), detachedCriteria ),
 			ormService  : arguments.ormService
 		);
 
@@ -51,7 +45,7 @@ component accessors="true" extends="cborm.models.criterion.BaseBuilder" {
 	/**
 	 * pass off arguments to higher-level restriction builder, and handle the results
 	 *
-	 * @missingMethodName     
+	 * @missingMethodName
 	 * @missingMethodArguments
 	 */
 	any function onMissingMethod( required string missingMethodName, required struct missingMethodArguments ){


### PR DESCRIPTION
Resolves CBORM-34 - Fixes an issue where SubQueries was being created as a singleton.   The root cause of this issue is due to WIREBOX-126.  

Because `SubQueries` extends a singleton, the `scope="noscope"` attribute was not being picked up because the `singleton` attribute is evaluated on line 550 of `Mapping.cfc` with an `else-if` to the scope, which is next in line.