### PR TITLE
🐛 FIX: Correct build:docs script bugs

### DIFF
--- a/build/Build.cfc
+++ b/build/Build.cfc
@@ -130,9 +130,7 @@ component {
 			)
 			.toConsole();
 
-		// Prepare exports directory
-		variables.exportsDir = variables.artifactsDir & "/#projectName#/#arguments.version#";
-		directoryCreate( variables.exportsDir, true, true );
+		ensureExportDir( argumentCollection = arguments );
 
 		// Project Build Dir
 		variables.projectBuildDir = variables.buildDir & "/#projectName#";
@@ -200,11 +198,12 @@ component {
 		version   = "1.0.0",
 		outputDir = ".tmp/apidocs"
 	){
+		ensureExportDir( argumentCollection = arguments );
+
 		// Create project mapping
 		fileSystemUtil.createMapping( arguments.projectName, variables.cwd );
 		// Generate Docs
 		print.greenLine( "Generating API Docs, please wait..." ).toConsole();
-		directoryCreate( arguments.outputDir, true, true );
 
 		command( "docbox generate" )
 			.params(
@@ -315,4 +314,18 @@ component {
 		return ( createObject( "java", "java.lang.System" ).getProperty( "cfml.cli.exitCode" ) ?: 0 );
 	}
 
+	/**
+	 * Ensure the export directory exists at artifacts/NAME/VERSION/
+	 */
+	private function ensureExportDir(
+		required projectName,
+		version   = "1.0.0"
+	){
+		if ( structKeyExists( variables, "exportsDir" ) && directoryExists( variables.exportsDir ) ){
+			return;
+		}
+		// Prepare exports directory
+		variables.exportsDir = variables.artifactsDir & "/#projectName#/#arguments.version#";
+		directoryCreate( variables.exportsDir, true, true );
+	}
 }

--- a/test-harness/tests/Application.cfc
+++ b/test-harness/tests/Application.cfc
@@ -48,15 +48,14 @@
 
 	// request start
 	public boolean function onRequestStart( String targetPage ){
-
 		// Set a high timeout for long running tests
-		setting requestTimeout="9999";
+		setting requestTimeout   ="9999";
 		// New ColdBox Virtual Application Starter
-		request.coldBoxVirtualApp = new coldbox.system.testing.VirtualApp( appMapping = "/root" );
+		request.coldBoxVirtualApp= new coldbox.system.testing.VirtualApp( appMapping = "/root" );
 
 		// ORM Reload for fresh results
-		if( structKeyExists( url, "fwreinit" ) ){
-			if( structKeyExists( server, "lucee" ) ){
+		if ( structKeyExists( url, "fwreinit" ) ) {
+			if ( structKeyExists( server, "lucee" ) ) {
 				pagePoolClear();
 			}
 			ormReload();

--- a/test-harness/tests/specs/ActiveEntityTest.cfc
+++ b/test-harness/tests/specs/ActiveEntityTest.cfc
@@ -19,21 +19,29 @@
 	function testWhenOperations(){
 		var results = "";
 
-		activeUser.when( false, function( user ){
-			results = true;
-		}, function( user ){
-			results = false;
-		} );
+		activeUser.when(
+			false,
+			function( user ){
+				results = true;
+			},
+			function( user ){
+				results = false;
+			}
+		);
 
-		expect(	results ).toBeFalse();
+		expect( results ).toBeFalse();
 
-		activeUser.when( true, function( user ){
-			results = true;
-		}, function( user ){
-			results = false;
-		} );
+		activeUser.when(
+			true,
+			function( user ){
+				results = true;
+			},
+			function( user ){
+				results = false;
+			}
+		);
 
-		expect(	results ).toBeTrue();
+		expect( results ).toBeTrue();
 	}
 
 	function testEvictionByEntityObject(){

--- a/test-harness/tests/specs/util/ORMUtilFactoryTest.cfc
+++ b/test-harness/tests/specs/util/ORMUtilFactoryTest.cfc
@@ -28,7 +28,6 @@ component extends="testbox.system.BaseSpec" {
 				},
 				skip = isLucee
 			);
-
 		} );
 	}
 


### PR DESCRIPTION
Fixes:

1. An error when running box run-script build:docs because variables.exportsDir doesn't exist.
2. The directoryCreate( outputDir ) is worse than useless, since DocBox creates this dir for you, and this code creates the wrong directory anyway! (it creates .tmp/apidocs/ inside the build/ directory, which is not where it should be.)