### PR TITLE
🐛 FIX: Update GHA to avoid deprecated syntax

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: taiki-e/create-gh-release-action@v1.5.0
+      - uses: taiki-e/create-gh-release-action@v1.6.1
         with:
           # Produced by the build/Build.cfc
           changelog: changelog.md

--- a/models/criterion/CriteriaBuilder.cfc
+++ b/models/criterion/CriteriaBuilder.cfc
@@ -176,7 +176,7 @@ component accessors="true" extends="cborm.models.criterion.BaseBuilder" {
 	/**
 	 * pass off arguments to higher-level restriction builder, and handle the results
 	 *
-	 * @missingMethodName
+	 * @missingMethodName     
 	 * @missingMethodArguments
 	 */
 	any function onMissingMethod( required string missingMethodName, required struct missingMethodArguments ){

--- a/models/criterion/DetachedCriteriaBuilder.cfc
+++ b/models/criterion/DetachedCriteriaBuilder.cfc
@@ -51,7 +51,7 @@ component accessors="true" extends="cborm.models.criterion.BaseBuilder" {
 	/**
 	 * pass off arguments to higher-level restriction builder, and handle the results
 	 *
-	 * @missingMethodName
+	 * @missingMethodName     
 	 * @missingMethodArguments
 	 */
 	any function onMissingMethod( required string missingMethodName, required struct missingMethodArguments ){


### PR DESCRIPTION
The [create-gh-release-action](https://github.com/taiki-e/create-gh-release-action) needs updating to avoid GitHub's deprecated `set-output` syntax.

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/